### PR TITLE
List and string access

### DIFF
--- a/BNAC/Statement.cs
+++ b/BNAC/Statement.cs
@@ -30,6 +30,7 @@ namespace BNAC
 		OP_LOG,
 		OP_ROUND,
 		OP_LIST,
+		OP_APPEND,
 
 		// test operations
 		OP_TEST_GT,
@@ -269,6 +270,15 @@ namespace BNAC
 					candidate.AddTokenOfKeywords( tokens.Dequeue( ) , new List<Keyword> { Keyword.SIZE } );
 					candidate.AddTokenOfTypes( tokens.Dequeue( ) , new List<TokenType> { TokenType.VARIABLE , TokenType.LITERAL } , operand: 2 );
 					candidate.Type = StatementType.OP_LIST;
+					break;
+				}
+
+				// APPEND var|lit TO var
+				case Keyword.APPEND: {
+					candidate.AddTokenOfTypes( tokens.Dequeue( ) , new List<TokenType> { TokenType.VARIABLE , TokenType.LITERAL } , operand: 2 );
+					candidate.AddTokenOfKeywords( tokens.Dequeue( ) , new List<Keyword> { Keyword.TO } );
+					candidate.AddTokenOfTypes( tokens.Dequeue( ) , new List<TokenType> { TokenType.VARIABLE } , operand: 1 );
+					candidate.Type = StatementType.OP_APPEND;
 					break;
 				}
 

--- a/BNAC/Statement.cs
+++ b/BNAC/Statement.cs
@@ -29,6 +29,7 @@ namespace BNAC
 		OP_MOD,
 		OP_LOG,
 		OP_ROUND,
+		OP_LIST,
 
 		// test operations
 		OP_TEST_GT,
@@ -259,6 +260,15 @@ namespace BNAC
 					candidate.AddTokenOfKeywords( tokens.Dequeue( ) , new List<Keyword> { Keyword.IF } );
 					candidate.AddTokenOfTypes( tokens.Dequeue( ) , new List<TokenType> { TokenType.VARIABLE , TokenType.LITERAL } , operand: 2 );
 					candidate.Type = StatementType.OP_GOTO;
+					break;
+				}
+
+				// LIST var SIZE var|lit
+				case Keyword.LIST: {
+					candidate.AddTokenOfTypes( tokens.Dequeue( ) , new List<TokenType> { TokenType.VARIABLE } , operand: 1 );
+					candidate.AddTokenOfKeywords( tokens.Dequeue( ) , new List<Keyword> { Keyword.SIZE } );
+					candidate.AddTokenOfTypes( tokens.Dequeue( ) , new List<TokenType> { TokenType.VARIABLE , TokenType.LITERAL } , operand: 2 );
+					candidate.Type = StatementType.OP_LIST;
 					break;
 				}
 

--- a/BNAC/Token.cs
+++ b/BNAC/Token.cs
@@ -94,8 +94,7 @@ namespace BNAC
 		/// <param name="type">The Token's type; if unknown, will attempt identifying</param>
 		private Token( string value, TokenType type = TokenType.UNKNOWN )
 		{
-			// Convert everything to uppercase so we can assume that later
-			Value = value.ToUpper();
+			Value = value;
 			Type = type;
 			Type = IdentifyType( );
 		}
@@ -131,7 +130,7 @@ namespace BNAC
 				}
 
 				// Keyword
-				if ( TryParseKeyword( Value , out var keyword ) ) {
+				if ( TryParseKeyword( Value.ToUpper() , out var keyword ) ) {
 					return TokenType.KEYWORD;
 				}
 
@@ -226,7 +225,7 @@ namespace BNAC
 							candidate += c;
 							break;
 
-						// String end
+						// String start
 						case '"':
 							inString = true;
 							candidate += c;

--- a/BNAC/Token.cs
+++ b/BNAC/Token.cs
@@ -27,6 +27,7 @@ namespace BNAC
 		MOD,
 		LOG,
 		ROUND,
+		LIST,
 
 		// Operation mid keywords
 		TO,
@@ -36,6 +37,7 @@ namespace BNAC
 		IF,
 		WITH,
 		OF,
+		SIZE,
 	}
 
 	enum Symbol
@@ -49,6 +51,7 @@ namespace BNAC
 		LABEL_START = '^',
 		LABEL_END = ':',
 		LINE_END = '\n',
+		ACCESSOR = '@',
 	}
 
 	enum TokenType
@@ -161,7 +164,10 @@ namespace BNAC
 			bool inString = false;
 			foreach ( char c in line ) {
 				// Letters, numbers, underscores, or anything in a string passes
-				if ( char.IsLetterOrDigit( c ) || c == '_' || inString ) {
+				if ( char.IsLetterOrDigit( c )
+					|| c == '_'
+					|| inString ) {
+
 					candidate += c;
 
 					if ( c == '"' ) {
@@ -177,6 +183,8 @@ namespace BNAC
 				// Other special characters
 				else {
 					switch ( c ) {
+						// ACCESSOR
+						case (char)Symbol.ACCESSOR:
 						// LABEL_START
 						case (char)Symbol.LABEL_START:
 						// LABEL_END

--- a/BNAC/Token.cs
+++ b/BNAC/Token.cs
@@ -28,6 +28,7 @@ namespace BNAC
 		LOG,
 		ROUND,
 		LIST,
+		APPEND,
 
 		// Operation mid keywords
 		TO,
@@ -163,9 +164,10 @@ namespace BNAC
 			string candidate = "";
 			bool inString = false;
 			foreach ( char c in line ) {
-				// Letters, numbers, underscores, or anything in a string passes
+				// Letters, numbers, underscores, accessor, or anything in a string passes
 				if ( char.IsLetterOrDigit( c )
 					|| c == '_'
+					|| c == (char)Symbol.ACCESSOR
 					|| inString ) {
 
 					candidate += c;

--- a/BNAC/Token.cs
+++ b/BNAC/Token.cs
@@ -322,8 +322,13 @@ namespace BNAC
 					// Do nothing
 				}
 			}
-			if ( !success )
-				throw new Exception( "Token not of given keywords" + keywords.ToString() + ": " + ToString() );
+			if ( !success ) {
+				string message = "Token not of given keywords [ ";
+				foreach ( Keyword s in keywords )
+					message += s.ToString( ) + " ";
+				message += "]: " + ToString( );
+				throw new Exception( message );
+			}
 		}
 
 		/// <summary>
@@ -354,8 +359,13 @@ namespace BNAC
 					// Do nothing
 				}
 			}
-			if ( !success )
-				throw new Exception( "Token not of given symbols" + symbols.ToString( ) + ": " + ToString( ) );
+			if ( !success ) {
+				string message = "Token not of given symbols [ ";
+				foreach ( Symbol s in symbols )
+					message += s.ToString( ) + " ";
+				message += ": " + ToString( );
+				throw new Exception( message );
+			}	
 		}
 
 		/// <summary>

--- a/BNAC/Translator.cs
+++ b/BNAC/Translator.cs
@@ -121,13 +121,13 @@ namespace BNAC
 
 					// Test operations
 					case StatementType.OP_TEST_GT:
-						str.AppendLine( indent + "SUCCESS = 1 if " + PythonOperand(statement, 1) + " > " + PythonOperand(statement, 2) + " else 0" );
+						str.AppendLine( indent + "success = 1 if " + PythonOperand(statement, 1) + " > " + PythonOperand(statement, 2) + " else 0" );
 						break;
 					case StatementType.OP_TEST_LT:
-						str.AppendLine( indent + "SUCCESS = 1 if " + PythonOperand(statement, 1) + " < " + PythonOperand(statement, 2) + " else 0" );
+						str.AppendLine( indent + "success = 1 if " + PythonOperand(statement, 1) + " < " + PythonOperand(statement, 2) + " else 0" );
 						break;
 					case StatementType.OP_TEST_EQ:
-						str.AppendLine( indent + "SUCCESS = 1 if " + PythonOperand(statement, 1) + " = " + PythonOperand(statement, 2) + " else 0" );
+						str.AppendLine( indent + "success = 1 if " + PythonOperand(statement, 1) + " = " + PythonOperand(statement, 2) + " else 0" );
 						break;
 
 					// Misc operations

--- a/BNAC/Translator.cs
+++ b/BNAC/Translator.cs
@@ -11,6 +11,36 @@ namespace BNAC
 	class Translator
 	{
 		/// <summary>
+		/// Get an operand of a statement translated to Python.
+		/// </summary>
+		/// <param name="statement">Statement to take operand from</param>
+		/// <param name="operand">which operand to translate (defaults to 1)</param>
+		/// <returns>Python translation of a statement's operand</returns>
+		private static string PythonOperand( Statement statement, int operand = 1 )
+		{
+			string variable = operand == 1 ? statement.Operand1.Value : statement.Operand2.Value;
+			if ( operand == 1 )
+				variable = statement.Operand1.Value;
+			else if ( operand == 2 )
+				variable = statement.Operand2.Value;
+
+			if ( variable.Contains( '@' ) ) {
+				var regex = new System.Text.RegularExpressions.Regex( "^([A-Za-z_])+@([A-Za-z_]|[0-9])+$" );
+
+				if ( regex.IsMatch( variable ) ) {
+					int index = variable.IndexOf( '@' );
+					string list_part = variable.Substring( 0 , index );
+					string access_part = variable.Substring( index + 1 , variable.Length - (index + 1) );
+					return list_part + "[" + access_part + "]";
+				}
+				else {
+					throw new Exception( "Found accessor in variable, but operand doesn't match list access." );
+				}
+			}
+			return variable;
+		}
+
+		/// <summary>
 		/// Convert queue of Statements to Python code
 		/// </summary>
 		/// <param name="statements">Queue of BNA statements</param>
@@ -44,83 +74,83 @@ namespace BNAC
 				switch ( statement.Type ) {
 					// Math operations
 					case StatementType.OP_SET:
-						str.AppendLine( indent + statement.Operand1.Value + " = " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " = " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_ADD:
-						str.AppendLine( indent + statement.Operand1.Value + " += " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " += " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_SUB:
-						str.AppendLine( indent + statement.Operand1.Value + " -= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " -= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_MUL:
-						str.AppendLine( indent + statement.Operand1.Value + " *= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " *= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_DIV:
-						str.AppendLine( indent + statement.Operand1.Value + " /= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " /= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_OR:
-						str.AppendLine( indent + statement.Operand1.Value + " |= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " |= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_AND:
-						str.AppendLine( indent + statement.Operand1.Value + " &= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " &= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_XOR:
-						str.AppendLine( indent + statement.Operand1.Value + " ^= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " ^= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_NEG:
-						str.AppendLine( indent + statement.Operand1.Value + " = ~" + statement.Operand1.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " = ~" + PythonOperand(statement, 1) );
 						break;
 					case StatementType.OP_POW:
-						str.AppendLine( indent + statement.Operand1.Value + " **= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " **= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_MOD:
-						str.AppendLine( indent + statement.Operand1.Value + " %= " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " %= " + PythonOperand(statement, 2) );
 						break;
 					case StatementType.OP_LOG:
-						str.AppendLine( indent + statement.Operand1.Value + " = math.log(" + statement.Operand1.Value + ", " + statement.Operand2.Value + ")" );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " = math.log(" + PythonOperand(statement, 1) + ", " + PythonOperand(statement, 2) + ")" );
 						break;
 					case StatementType.OP_ROUND:
-						str.AppendLine( indent + statement.Operand1.Value + " = round(" + statement.Operand1.Value + ")" );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " = round(" + PythonOperand(statement, 1) + ")" );
 						break;
 					case StatementType.OP_LIST:
-						str.AppendLine( indent + statement.Operand1.Value + " = [0] * " + statement.Operand2.Value );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " = [0] * " + PythonOperand(statement, 2) );
 						break;
 					
 					// Test operations
 					case StatementType.OP_TEST_GT:
-						string op1 = statement.Operand1.Value;
-						string op2 = statement.Operand2.Value;
+						string op1 = PythonOperand(statement, 1);
+						string op2 = PythonOperand(statement, 2);
 						if ( statement.Operand1.Type == TokenType.STRING || statement.Operand2.Type == TokenType.STRING ) {
-							op1 = "str(" + statement.Operand1.Value + ")";
-							op2 = "str(" + statement.Operand2.Value + ")";
+							op1 = "str(" + PythonOperand(statement, 1) + ")";
+							op2 = "str(" + PythonOperand(statement, 2) + ")";
 						}
-						str.AppendLine( indent + "SUCCESS = 1 if " + statement.Operand1.Value + " > " + statement.Operand2.Value + " else 0" );
+						str.AppendLine( indent + "SUCCESS = 1 if " + PythonOperand(statement, 1) + " > " + PythonOperand(statement, 2) + " else 0" );
 						break;
 					case StatementType.OP_TEST_LT:
-						str.AppendLine( indent + "SUCCESS = 1 if " + statement.Operand1.Value + " < " + statement.Operand2.Value + " else 0" );
+						str.AppendLine( indent + "SUCCESS = 1 if " + PythonOperand(statement, 1) + " < " + PythonOperand(statement, 2) + " else 0" );
 						break;
 					case StatementType.OP_TEST_EQ:
-						str.AppendLine( indent + "SUCCESS = 1 if " + statement.Operand1.Value + " = " + statement.Operand2.Value + " else 0" );
+						str.AppendLine( indent + "SUCCESS = 1 if " + PythonOperand(statement, 1) + " = " + PythonOperand(statement, 2) + " else 0" );
 						break;
 
 					// Misc operations
 					case StatementType.OP_RAND:
-						str.AppendLine( indent + statement.Operand1.Value + " = random.randint(0, " + statement.Operand2.Value + ")" );
+						str.AppendLine( indent + PythonOperand(statement, 1) + " = random.randint(0, " + PythonOperand(statement, 2) + ")" );
 						break;
 					case StatementType.OP_PRINT:
-						str.AppendLine( indent + "print(" + statement.Operand1.Value + ")" );
+						str.AppendLine( indent + "print(" + PythonOperand(statement, 1) + ")" );
 						break;
 					case StatementType.OP_WAIT:
-						str.AppendLine( indent + "time.sleep(" + statement.Operand1.Value + ")" );
+						str.AppendLine( indent + "time.sleep(" + PythonOperand(statement, 1) + ")" );
 						break;
 
 					// Control flow
 					case StatementType.LABEL:
-						str.AppendLine( indent + "label ." + statement.Operand1.Value );
+						str.AppendLine( indent + "label ." + PythonOperand(statement, 1) );
 						break;
 					case StatementType.OP_GOTO:
-						str.AppendLine( indent + "if " + statement.Operand2.Value + " != 0 :" );
-						str.AppendLine( indent + "\tgoto ." + statement.Operand1.Value );
+						str.AppendLine( indent + "if " + PythonOperand(statement, 2) + " != 0 :" );
+						str.AppendLine( indent + "\tgoto ." + PythonOperand(statement, 1) );
 						break;
 
 					// Shouldn't happen

--- a/BNAC/Translator.cs
+++ b/BNAC/Translator.cs
@@ -82,7 +82,10 @@ namespace BNAC
 					case StatementType.OP_ROUND:
 						str.AppendLine( indent + statement.Operand1.Value + " = round(" + statement.Operand1.Value + ")" );
 						break;
-
+					case StatementType.OP_LIST:
+						str.AppendLine( indent + statement.Operand1.Value + " = [0] * " + statement.Operand2.Value );
+						break;
+					
 					// Test operations
 					case StatementType.OP_TEST_GT:
 						string op1 = statement.Operand1.Value;

--- a/BNAC/Translator.cs
+++ b/BNAC/Translator.cs
@@ -115,15 +115,12 @@ namespace BNAC
 					case StatementType.OP_LIST:
 						str.AppendLine( indent + PythonOperand(statement, 1) + " = [0] * " + PythonOperand(statement, 2) );
 						break;
-					
+					case StatementType.OP_APPEND:
+						str.AppendLine( indent + PythonOperand( statement , 1 ) + ".append(" + PythonOperand( statement , 2 ) + ")" );
+						break;
+
 					// Test operations
 					case StatementType.OP_TEST_GT:
-						string op1 = PythonOperand(statement, 1);
-						string op2 = PythonOperand(statement, 2);
-						if ( statement.Operand1.Type == TokenType.STRING || statement.Operand2.Type == TokenType.STRING ) {
-							op1 = "str(" + PythonOperand(statement, 1) + ")";
-							op2 = "str(" + PythonOperand(statement, 2) + ")";
-						}
 						str.AppendLine( indent + "SUCCESS = 1 if " + PythonOperand(statement, 1) + " > " + PythonOperand(statement, 2) + " else 0" );
 						break;
 					case StatementType.OP_TEST_LT:


### PR DESCRIPTION
- Added lists with LIST `op1 SIZE op2` operation ( Issue #4 )
- Added list access using `@` (e.g., `foo@bar` or `fish@2`)
- Added string character access with `@` ( Issue #3 )
- Added `APPEND` operation to add to an existing list
- Fixed variables being non case sensitive. ( Issue #12 )